### PR TITLE
removed fixed version of compiler-cli preventing install

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular-eslint/eslint-plugin-template": "12.1.0",
     "@angular-eslint/template-parser": "12.1.0",
     "@angular/cli": "~12.0.3",
-    "@angular/compiler-cli": "12.0.3",
+    "@angular/compiler-cli": "~12.0.3",
     "@angular/language-service": "~12.0.3",
     "@types/jasmine": "~3.7.7",
     "@types/jasminewd2": "~2.0.9",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

```
npm i
```

was broken due to a fixed version of `@angular/compile-cli`, this preventing `npm i` working.

**Related github/jira issue (required)**:

N/A

**Steps necessary to review your pull request (required)**:

```sh
git clone c:/git/github/infor-design/enterprise-ng-quickstart.git
cd enterprise-ng-quickstart
npm i
```

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->

